### PR TITLE
Fix SchemaOrg.js with value to logo for publisher

### DIFF
--- a/src/components/SEO/SchemaOrg.js
+++ b/src/components/SEO/SchemaOrg.js
@@ -61,7 +61,10 @@ export default React.memo(
             publisher: {
               '@type': 'Organization',
               url: organization.url,
-              logo: organization.logo,
+              logo: {
+                '@type': 'ImageObject',
+                url: organization.logo
+              },
               name: organization.name,
             },
             mainEntityOfPage: {


### PR DESCRIPTION
this is a fix for the logo value inside publisher settings for schema.org. 
Otherwise the testing tool returns an error: https://search.google.com/structured-data/testing-tool/
It is also advisable to insert a height and a width inside the logo, but not necessarily.